### PR TITLE
edit "generate_lr_geneset" function

### DIFF
--- a/R/liana_tensor.R
+++ b/R/liana_tensor.R
@@ -529,14 +529,16 @@ plot_lr_heatmap <- function(sce,
 
 
 #' Generate a geneset resource for each LR
-#' @param lrs lrs a tibble with `lr`
+#' @param sce SingleCellExperiment object with liana_tensor_c2c computed
 #' @param resource resource with `source`, `target`, `weight` columns
 #'
 #' @export
 #'
 #' @returns a tibble in decoupleR format
-generate_lr_geneset <- function(lrs, resource, lr_sep="^"){
+generate_lr_geneset <- function(sce, resource, lr_sep="^"){
 
+    # Take SingleCellExperiment object as param instead of lrs to avoid the conflict of declaring 'factors' as global variable
+    factors <- get_c2c_factors(sce)
     lrs <- factors$interactions %>%
         separate(lr, sep=str_glue("\\{lr_sep}"), into=c("ligand", "receptor"))
 


### PR DESCRIPTION
First of all, thank you for developing such an amazing tool! 

In addition, I found that generate_lr_geneset() function take lrs as a param but within the function it declare lrs object from factors$interactions, which has to be declare globally for the function to work as intended.