### PR TITLE
Fixed SCpubr's broken reference link in liana_tutorial.Rmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ inst/cytosig_signature_centroid.csv
 .Rhistory
 LIANA.Rproj
 .gitattributes
+liana.Rproj
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 LIANA enables the use of any combination of ligand-receptor methods and resources, and their consensus. A faster and memory efficient Python implementation is available [here](https://github.com/saezlab/liana-py).
     
 ## Install LIANA  
-```{r}
+```r
 if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 

--- a/vignettes/liana_tutorial.Rmd
+++ b/vignettes/liana_tutorial.Rmd
@@ -208,7 +208,7 @@ p <- chord_freq(liana_trunc,
 ```
 
 
-For more advanced visualization options, we kindly refer the user to [SCPubr](https://enblacar.github.io/SCpubr-book/21-LigandReceptorPlot.html).
+For more advanced visualization options, we kindly refer the user to [SCpubr](https://github.com/enblacar/SCpubr/) (see [`SCpubr::do_LigandReceptorPlot()`](https://enblacar.github.io/SCpubr-book-v1/21-LigandReceptorPlot.html)).
 
 
 ## Run any method of choice.


### PR DESCRIPTION
Hi @dbdimitrov,

I would like to propose the following changes to `liana`:

- Added `liana.Rproj` to `.gitignore` to prevent the RStudio project file to be tracked by git.
- Enabled R syntax highlight in the `README.md` file to make it prettier.
- Fixed `SCpubr`'s reference in `liana_tutorial.Rmd`, as the link was broken. This is due to me shifting the current website documentation to a new version. Therefore, I have added a link to both the repo and the `SCpubr::do_LigandReceptorPlot()` old function documentation that is available in another link until the website migration to the new version is done. 

I hope you find the changes suitable! 

Similarly, if you agree, I have some ideas for theme enhancements to the DotPlot function to make it a bit more aesthetically pleasant. While this is pretty much a personal preference, let me know if this would be interesting for you!

Best,
Enrique